### PR TITLE
Fix pagination for merchandise page

### DIFF
--- a/client/src/components/RecordList/index.js
+++ b/client/src/components/RecordList/index.js
@@ -7,71 +7,39 @@ import {
   Button,
   ButtonGroup,
 } from '@chakra-ui/react';
-import {
-    ArrowBackIcon,
-    ArrowForwardIcon
-} from '@chakra-ui/icons'
+import { ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
 import Record from '../Record';
 import { useMutation, useQuery } from '@apollo/client';
 import { QUERY_MANY_RECORDS } from '../../utils/queries';
 
-
-export default function RecordList() {
-  const { loading, data } = useQuery(QUERY_MANY_RECORDS);
-  const [pageIndex, setPageIndex] = useState(0);
+export default function RecordList({ offset }) {
+  const { loading, data } = useQuery(QUERY_MANY_RECORDS, {
+    variables: { 
+      offset: (offset-1)*8,
+      limit: 8
+     },
+  });
   const records = data?.records || [];
-  let recordChunks = [];
-  let pages = [];
-  if (!loading) {
-    for (let i = 0; i < records.length; i += 8) {
-      const chunk = records.slice(i, i + 8);
-      recordChunks.push(chunk);
-      pages.push(i / 8 + 1);
-    }
-  }
-  const handleBackClick = () => {
-    if (pageIndex !== 0) {
-        setPageIndex(pageIndex-1);
-    }
-  }
-  const handleForwardClick = () => {
-    if (pageIndex !== pages[pages.length-1]) {
-        setPageIndex(pageIndex+1);
-    }
-  }
   return (
-    <>
-      <GridItem rowSpan={2.3} colSpan={8}>
-        <SimpleGrid columns={{ sm: 1, md: 2, lg: 4 }}>
-          {loading ? (
-            <Spinner />
-          ) : (
-            recordChunks[pageIndex].map((record) => (
-              <Record
-                key={record._id}
-                id={record._id}
-                image={record.imageUrl}
-                title={record.albumTitle}
-                artist={record.artist}
-                comments={record.comments}
-                quantity={record.quantity}
-                price={`${record.price}`}
-              />
-            ))
-          )}
-        </SimpleGrid>
-      </GridItem>
-      <GridItem rowSpan={1} colSpan={8}>
-      <ButtonGroup>
-        <Button onClick={handleBackClick} variant={'solid'}><ArrowBackIcon/></Button>
-        {pages.map((page) => (
-          <Button key={page} variant={'outline'} color="gray.800" id={page}>
-            {page}
-          </Button>
-        ))}
-        <Button onClick={handleForwardClick} variant={'solid'}><ArrowForwardIcon/></Button>
-      </ButtonGroup>
-      </GridItem>
-    </>
+    <GridItem rowSpan={2.3} colSpan={8}>
+      <SimpleGrid columns={{ sm: 1, md: 2, lg: 4 }}>
+        {loading ? (
+          <Spinner />
+        ) : (
+          records.map((record) => (
+            <Record
+              key={record._id}
+              id={record._id}
+              image={record.imageUrl}
+              title={record.albumTitle}
+              artist={record.artist}
+              comments={record.comments}
+              quantity={record.quantity}
+              price={`${record.price}`}
+            />
+          ))
+        )}
+      </SimpleGrid>
+    </GridItem>
   );
 }

--- a/client/src/pages/Merchandise.js
+++ b/client/src/pages/Merchandise.js
@@ -2,14 +2,56 @@ import React, { useState, useEffect } from "react";
 import {
   GridItem,
   Grid,
+  ButtonGroup,
+  Button,
+  Spinner
 } from "@chakra-ui/react";
-
+import {
+  ArrowBackIcon,
+  ArrowForwardIcon
+}  from '@chakra-ui/icons';
+import { QUERY_MANY_RECORDS } from "../utils/queries";
+import { useQuery } from "@apollo/client";
 import FilterBar from "../components/FilterBar";
 import RecordList from '../components/RecordList';
 
 
 
 function Merchandise() {
+  const [page, setPage] = useState(1);
+  const { loading, data } = useQuery(QUERY_MANY_RECORDS);
+  const records = data?.records || [];
+  let pages = [];
+  if (!loading) {
+    for (let i = 0; i< records.length; i+=8) {
+      pages.push(i/8+1);
+    }
+  }
+  const handlePageClick = (p) => {
+    setPage(p.target.value);
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  }
+  const handleForwardClick = () => {
+    if (page !== pages.length) {
+      setPage(page+1);
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth'
+      });
+    }
+  }
+  const handleBackClick = () => {
+    if (page !== 1) {
+      setPage(page-1);
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth'
+      });
+    }
+  }
   return (
     <Grid
       h="100vw"
@@ -20,7 +62,14 @@ function Merchandise() {
       <GridItem rowSpan={4} colSpan={2}>
         <FilterBar />
       </GridItem>
-      <RecordList/>
+      <RecordList offset={page}/>
+      <ButtonGroup>
+        <Button variant={'solid'} onClick={handleBackClick}><ArrowBackIcon/></Button>
+        {loading ? <Spinner/> : pages.map((p) => (
+          <Button key={p} variant='outline' onClick={handlePageClick} value={p}>{p}</Button>
+        ))}
+        <Button variant={'solid'} onClick={handleForwardClick}><ArrowForwardIcon/></Button>
+      </ButtonGroup>
     </Grid>
   );
 }

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -1,8 +1,18 @@
 import { gql } from '@apollo/client';
 
 export const QUERY_MANY_RECORDS = gql`
-  query Records($offset: Int, $albumTitle: String, $artist: String) {
-    records(offset: $offset, albumTitle: $albumTitle, artist: $artist) {
+  query Records(
+    $offset: Int
+    $albumTitle: String
+    $artist: String
+    $limit: Int
+  ) {
+    records(
+      offset: $offset
+      albumTitle: $albumTitle
+      artist: $artist
+      limit: $limit
+    ) {
       _id
       albumTitle
       artist

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -14,8 +14,8 @@ const resolvers = {
 
       throw new AuthenticationError('Not logged in');
     },
-    records: async (parent, {artist, albumTitle, offset}) => {
-      const recordData = await Record.find().skip(offset);
+    records: async (parent, {artist, albumTitle, offset, limit}) => {
+      const recordData = await Record.find().skip(offset).limit(limit);
       // Record.find().skip(offset).limit(12).where('artist').equals(artist).where('albumTitle').equals(albumTitle);
       return recordData;
     },

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -51,7 +51,7 @@ const typeDefs = gql`
 
   type Query {
     user: User
-    records(artist: String, albumTitle: String, offset: Int): [Record]
+    records(artist: String, albumTitle: String, offset: Int, limit: Int): [Record]
     record(_id: ID!): Record
     order(_id: ID!): Order
     checkout(records: [ID]!): Checkout


### PR DESCRIPTION
Changed resolvers, typedefs, and queries to fix pagination. Moved page as a prop passed into record list and included limit and offset. Each button should scroll accordingly to the page. The pages should automatically calculate how many pages are necessary and which to click.